### PR TITLE
mark-devkit: Bump app-office/unoconv-0.8.2-r1

### DIFF
--- a/app-office/unoconv/unoconv-0.8.2-r1.ebuild
+++ b/app-office/unoconv/unoconv-0.8.2-r1.ebuild
@@ -24,6 +24,7 @@ DEPEND=""
 RDEPEND="${DEPEND}
 	${PYTHON_DEPS}
 	!app-text/odt2txt
+	virtual/ooo
 "
 
 src_prepare() {


### PR DESCRIPTION
Automatic bump of package app-office/unoconv-0.8.2-r1 for branch mark-iii by mark-bot