### PR TITLE
mark-devkit: Bump sys-process/evisum-0.6.4-r1

### DIFF
--- a/sys-process/evisum/evisum-0.6.4-r1.ebuild
+++ b/sys-process/evisum/evisum-0.6.4-r1.ebuild
@@ -15,4 +15,4 @@ KEYWORDS="*"
 DEPEND="dev-libs/efl"
 RDEPEND="|| ( dev-libs/efl[X] dev-libs/efl[wayland] )"
 
-DOCS=( BUGS NEWS TODO )
+DOCS=( BUGS NEWS README TODO )


### PR DESCRIPTION
Automatic bump of package sys-process/evisum-0.6.4-r1 for branch mark-iii by mark-bot