### PR TITLE
mark-devkit: Bump net-misc/remmina-1.4.40-r1

### DIFF
--- a/net-misc/remmina/remmina-1.4.40-r1.ebuild
+++ b/net-misc/remmina/remmina-1.4.40-r1.ebuild
@@ -73,8 +73,8 @@ src_configure() {
 		-DWITH_AVAHI=$(usex zeroconf)
 		-DWITH_CUPS=$(usex cups)
 		-DWITH_EXAMPLES=$(usex examples)
-		-DWITH_FREERDP=OFF
-		-DWITH_FREERDP3=$(usex rdp)
+		-DWITH_FREERDP=$(usex rdp)
+		-DWITH_FREERDP3=OFF
 		-DWITH_GCRYPT=$(usex crypt)
 		-DWITH_GETTEXT=$(usex nls)
 		-DWITH_ICON_CACHE=OFF


### PR DESCRIPTION
Automatic bump of package net-misc/remmina-1.4.40-r1 for branch mark-iii by mark-bot