### PR TITLE
mark-devkit: [mark-31] Bump net-irc/hexchat-2.16.1-r1

### DIFF
--- a/net-irc/hexchat/hexchat-2.16.1-r1.ebuild
+++ b/net-irc/hexchat/hexchat-2.16.1-r1.ebuild
@@ -48,7 +48,6 @@ RDEPEND="
 
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-util/glib-utils
 	app-arch/xz-utils
 	app-text/iso-codes
 	sys-devel/gettext


### PR DESCRIPTION
Automatic bump of package net-irc/hexchat-2.16.1-r1 for branch mark-31 by mark-bot